### PR TITLE
Fixed warning for missing prototype

### DIFF
--- a/Extensions/b64.m
+++ b/Extensions/b64.m
@@ -94,6 +94,8 @@ VERSION HISTORY:
 #import "b64.h"
 #import <Foundation/Foundation.h>
 
+void decodeblock( unsigned char in[4], unsigned char out[3] );
+
 /*
 ** Translation Table as described in RFC1113
 */


### PR DESCRIPTION
These is a function with a missing prototype and Xcode is complaining about that. The prototype has been added to get rid of the warning.
