### PR TITLE
Fixed error when reading with AQGZipStream into AQXMLParser using HTTPMessage

### DIFF
--- a/Compression/AQGzipInputStream.m
+++ b/Compression/AQGzipInputStream.m
@@ -182,7 +182,7 @@
                 
                 // attempt to decompress some data
                 status = inflate( _internal.zStream, Z_SYNC_FLUSH );
-                if ( status < Z_OK )
+                if ( status < Z_OK && status != Z_BUF_ERROR)
                 {
                     [stream close];
                     [_internal setZlibError: status];

--- a/Compression/AQGzipInputStream.m
+++ b/Compression/AQGzipInputStream.m
@@ -108,7 +108,7 @@
 
 - (void) close
 {
-    if ( _internal.status == NSStreamStatusNotOpen )
+    if ( _internal.status == NSStreamStatusNotOpen || _internal.status == NSStreamStatusClosed )
         return;
     
     int err = inflateEnd( _internal.zStream );

--- a/HTTPMessage/HTTPMessage.m
+++ b/HTTPMessage/HTTPMessage.m
@@ -200,11 +200,11 @@
 }
 
 - (void) setUseGzipEncoding: (BOOL) useGzip
-{/*
+{
     if ( useGzip )
         [self setValue: @"gzip" forHeaderField: @"Accept-Encoding"];
     else
-        [self setValue: nil forHeaderField: @"Accept-Encoding"];*/
+        [self setValue: nil forHeaderField: @"Accept-Encoding"];
 }
 
 - (NSData *) serializedMessage


### PR DESCRIPTION
I was having an error with AQGZipInputStream used together with AQXMLParser and HTTPMessage, where the stream would throw a Z_BUF_ERROR with no error message, while bytes where still available to read from the buffer. This fix commit solves the issue, but it might be other ways to fix it. 

http://zlib,net has further explanation:

> inflate() can also return Z_STREAM_ERROR, which should not be possible here, but could be checked for as >noted above for def(). Z_BUF_ERROR does not need to be checked for here, for the same reasons noted for >def(). Z_STREAM_END will be checked for later.

Also, in some cases when used together with GCD, I would experience issues with close being called twice on the same stream. A check if status equals NSStreamStatusClosed solves this issue
