### PR TITLE
Changes to StreamingParser to work under latest llvm & ASLResponse NSEnumerator changes

### DIFF
--- a/AQToolkit.podspec
+++ b/AQToolkit.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
     ss.requires_arc = false
     ss.dependency 'AQToolkit/NSObject+Properties'
     ss.dependency 'AQToolkit/NSData+Base64'
+    ss.dependency 'AQToolkit/NSString+PropertyKVC'
   end
 
   s.subspec 'AQXMLParser' do |ss|
@@ -24,6 +25,10 @@ Pod::Spec.new do |s|
     ss.libraries = 'xml2'
   end
 
+  ##
+  ## Extension subspecs used by main AQToolkit classes
+  ##
+
   s.subspec 'NSObject+Properties' do |ss|
     ss.source_files = 'Extensions/NSObject+Properties.{h,m}'
     ss.requires_arc = false
@@ -32,6 +37,12 @@ Pod::Spec.new do |s|
 
   s.subspec 'NSData+Base64' do |ss|
     ss.source_files = 'Extensions/NSData+Base64.{h,m}', 'Extensions/b64.{h,m}'
+    ss.requires_arc = false
+    ss.framework = 'Foundation'
+  end
+
+  s.subspec 'NSString+PropertyKVC' do |ss|
+    ss.source_files = 'Extensions/NSString+PropertyKVC.{h,m}'
     ss.requires_arc = false
     ss.framework = 'Foundation'
   end

--- a/AQToolkit.podspec
+++ b/AQToolkit.podspec
@@ -1,0 +1,39 @@
+Pod::Spec.new do |s|
+  s.name = 'AQToolkit'
+  s.version = '0.0.1'
+  s.license = { :type => 'BSD' }
+  s.homepage = 'https://github.com/AlanQuatermain/aqtoolkit'
+  s.authors = {
+    'Jim Dovey (aka Alan Quatermain)' => 'jimdovey@mac.com',
+    'Mark Aufflick' => 'mark@htb.io'
+  }
+  s.summary = 'A toolkit consisting of a bunch of generally useful routines and extensions I wrote when putting together other projects.'
+  
+  s.subspec 'ASLogger' do |ss|
+    ss.source_files = 'ASLogger'
+    ss.framework = 'Foundation'
+    ss.requires_arc = false
+    ss.dependency 'AQToolkit/NSObject+Properties'
+    ss.dependency 'AQToolkit/NSData+Base64'
+  end
+
+  s.subspec 'AQXMLParser' do |ss|
+    ss.source_files = 'StreamingXMLParser'
+    ss.framework = 'Foundation'
+    ss.requires_arc = false
+    ss.libraries = 'xml2'
+  end
+
+  s.subspec 'NSObject+Properties' do |ss|
+    ss.source_files = 'Extensions/NSObject+Properties.{h,m}'
+    ss.requires_arc = false
+    ss.framework = 'Foundation'
+  end
+
+  s.subspec 'NSData+Base64' do |ss|
+    ss.source_files = 'Extensions/NSData+Base64.{h,m}', 'Extensions/b64.{h,m}'
+    ss.requires_arc = false
+    ss.framework = 'Foundation'
+  end
+
+end

--- a/ASLogger/ASLMessage.m
+++ b/ASLogger/ASLMessage.m
@@ -40,9 +40,6 @@
 #import "NSObject+Properties.h"
 #import "NSData+Base64.h"
 
-// yay for GC & objc_assign_global() !
-static NSDateFormatter * __formatter = nil;
-
 // asl.h doesn't define this, grrr....
 static const char * levelStrings[] = 
 {
@@ -154,16 +151,11 @@ static const char * levelStrings[] =
 		return ( nil );
 	
 	// convert to an NSDate
-	if ( __formatter == nil )
-	{
-		__formatter = [NSDateFormatter new];
-		[__formatter setFormatterBehavior: NSDateFormatterBehavior10_4];
-		
-		// date format is that used by ctime() - Thu Nov 24 18:22:48 1986
-		[__formatter setDateFormat: @"EEE MMM dd HH:mm:ss yyyy"];
-	}
-	
-	return ( [__formatter dateFromString: [NSString stringWithUTF8String: value]] );
+    NSInteger epochDate = [[NSString stringWithUTF8String:value] integerValue];
+    if (0 == epochDate)
+        return nil;
+    
+    return [NSDate dateWithTimeIntervalSince1970:epochDate];
 }
 
 - (NSHost *) host

--- a/ASLogger/ASLResponse.h
+++ b/ASLogger/ASLResponse.h
@@ -52,6 +52,7 @@
 + (ASLResponse *) responseWithResponse: (aslresponse) response;
 - (id) initWithResponse: (aslresponse) response;
 
+/// For backwards compatibility. You probably want to use the NSEnumerator methods or fast enumeration.
 - (ASLMessage *) next;
 
 @end

--- a/ASLogger/ASLResponse.h
+++ b/ASLogger/ASLResponse.h
@@ -41,7 +41,7 @@
 
 @class ASLMessage, ASLQuery;
 
-@interface ASLResponse : NSObject
+@interface ASLResponse : NSEnumerator
 {
 	aslresponse	_response;
 }

--- a/ASLogger/ASLResponse.m
+++ b/ASLogger/ASLResponse.m
@@ -84,7 +84,7 @@
 	[super finalize];
 }
 
-- (ASLMessage *) next
+- (ASLMessage *) nextObject
 {
 	aslmsg m = aslresponse_next( _response );
 	if ( m == NULL )
@@ -92,12 +92,12 @@
 	return ( [[[ASLMessage alloc] initWithResponseMessage: m] autorelease] );
 }
 
-- (id)nextObject
+- (id) next
 {
-    return [self next];
+    return [self nextObject];
 }
 
-- (NSArray *)allObjects
+- (NSArray *) allObjects
 {
     NSMutableArray * allObjects = [NSMutableArray array];
     id msg;

--- a/ASLogger/ASLResponse.m
+++ b/ASLogger/ASLResponse.m
@@ -92,4 +92,19 @@
 	return ( [[[ASLMessage alloc] initWithResponseMessage: m] autorelease] );
 }
 
+- (id)nextObject
+{
+    return [self next];
+}
+
+- (NSArray *)allObjects
+{
+    NSMutableArray * allObjects = [NSMutableArray array];
+    id msg;
+    while ((msg = [self next]))
+        [allObjects addObject:msg];
+    
+    return allObjects;
+}
+
 @end

--- a/CommonCrypto/NSData+CommonCrypto.m
+++ b/CommonCrypto/NSData+CommonCrypto.m
@@ -531,11 +531,45 @@ static void FixKeyLengths( CCAlgorithm algorithm, NSMutableData * keyData, NSMut
 	else
 		keyData = (NSData *) key;
 	
+	NSInteger digestLength = 0;
+	
+	switch (algorithm) {
+		case kCCHmacAlgSHA1:
+			digestLength = CC_SHA1_DIGEST_LENGTH;
+			break;
+			
+		case kCCHmacAlgMD5:
+			digestLength = CC_MD5_DIGEST_LENGTH;
+			break;
+			
+		case kCCHmacAlgSHA256:
+			digestLength = CC_SHA256_DIGEST_LENGTH;
+			break;
+			
+		case kCCHmacAlgSHA384:
+			digestLength = CC_SHA384_DIGEST_LENGTH;
+			break;
+			
+		case kCCHmacAlgSHA512:
+			digestLength = CC_SHA512_DIGEST_LENGTH;
+			break;
+			
+		case kCCHmacAlgSHA224:
+			digestLength = CC_SHA224_DIGEST_LENGTH;
+			break;
+			
+		default:
+			NSAssert(NO, @"Unkown CCHmacAlgorithm, could not detect digest length");
+			break;
+	}
+	
+	
 	// this could be either CC_SHA1_DIGEST_LENGTH or CC_MD5_DIGEST_LENGTH. SHA1 is larger.
-	unsigned char buf[CC_SHA1_DIGEST_LENGTH];
+	unsigned char buf[digestLength];
 	CCHmac( algorithm, [keyData bytes], [keyData length], [self bytes], [self length], buf );
 	
-	return ( [NSData dataWithBytes: buf length: (algorithm == kCCHmacAlgMD5 ? CC_MD5_DIGEST_LENGTH : CC_SHA1_DIGEST_LENGTH)] );
+	return ( [NSData dataWithBytes: buf length: digestLength] );
+
 }
 
 @end

--- a/CommonCrypto/NSData+CommonCrypto.m
+++ b/CommonCrypto/NSData+CommonCrypto.m
@@ -280,11 +280,11 @@ static void FixKeyLengths( CCAlgorithm algorithm, NSMutableData * keyData, NSMut
 	{
 		case kCCAlgorithmAES128:
 		{
-			if ( keyLength < 16 )
+			if ( keyLength <= 16 )
 			{
 				[keyData setLength: 16];
 			}
-			else if ( keyLength < 24 )
+			else if ( keyLength <= 24 )
 			{
 				[keyData setLength: 24];
 			}
@@ -310,7 +310,7 @@ static void FixKeyLengths( CCAlgorithm algorithm, NSMutableData * keyData, NSMut
 			
 		case kCCAlgorithmCAST:
 		{
-			if ( keyLength < 5 )
+			if ( keyLength <= 5 )
 			{
 				[keyData setLength: 5];
 			}

--- a/Compression/AQGzipFileStream.m
+++ b/Compression/AQGzipFileStream.m
@@ -53,6 +53,9 @@
     NSError *           _error;
     NSStreamStatus      _status;
 }
+
+- (id) initWithPath: (NSString *) path;
+
 @end
 
 @interface AQGzipFileOutputStream : NSOutputStream <AQGzipOutputCompressor>
@@ -66,6 +69,9 @@
     NSStreamStatus          _status;
     AQGzipCompressionLevel  _level;
 }
+
+- (id) initWithPath: (NSString *) path;
+
 @end
 
 @implementation AQGzipInputStream (GzipFileInput)
@@ -475,7 +481,7 @@ static CFRunLoopSourceRef RunloopSourceForStream( NSStream * stream, mach_port_t
     
     NSString * modeStr = @"w";
     if ( _level != AQGzipCompressionLevelDefault )
-        modeStr = [[NSString alloc] initWithFormat: @"w%ld", _level];
+        modeStr = [[NSString alloc] initWithFormat: @"w%d", _level];
     
     _file = gzopen( [_path fileSystemRepresentation], [modeStr UTF8String] );
     [modeStr release];

--- a/Compression/AQGzipStream.h
+++ b/Compression/AQGzipStream.h
@@ -72,7 +72,7 @@ typedef NSInteger AQGzipCompressionLevel;
 //  need to be subclasses of different parents
 // My way around this is for each thing to *contain* a common instance, which stores
 //  all the common state information, etc.
-@interface AQGzipInputStream : NSInputStream <AQGzipMemoryStreamOptimisation>
+@interface AQGzipInputStream : NSInputStream <AQGzipMemoryStreamOptimisation, NSStreamDelegate>
 {
     NSInputStream *         _compressedDataStream;
     _AQGzipStreamInternal * _internal;
@@ -85,7 +85,7 @@ typedef NSInteger AQGzipCompressionLevel;
 
 @end
 
-@interface AQGzipOutputStream : NSOutputStream <AQGzipMemoryStreamOptimisation, AQGzipOutputCompressor>
+@interface AQGzipOutputStream : NSOutputStream <AQGzipMemoryStreamOptimisation, AQGzipOutputCompressor, NSStreamDelegate>
 {
     NSOutputStream *        _outputStream;
     _AQGzipStreamInternal * _internal;

--- a/Extensions/NSError+CFStreamError.m
+++ b/Extensions/NSError+CFStreamError.m
@@ -36,6 +36,9 @@
  *
  */
 
+#import <Foundation/Foundation.h>
+#import <netdb.h>		// for gai_strerror()
+
 // weak-link symbols from CoreServices/CFNetwork frameworks
 #pragma weak kCFStreamErrorDomainMach
 #pragma weak kCFStreamErrorDomainNetDB
@@ -47,9 +50,6 @@
 #pragma weak kCFErrorDomainCFNetwork
 
 // the other domains, and the error codes themselves, are enumerated types & therefore aren't linked
-
-#import <Foundation/Foundation.h>
-#import <netdb.h>		// for gai_strerror()
 
 #if TARGET_OS_IPHONE
 #import <CFNetwork/CFNetwork.h>

--- a/Extensions/NSError+CFStreamError.m
+++ b/Extensions/NSError+CFStreamError.m
@@ -88,9 +88,9 @@
 		else if ( streamError.domain == kCFStreamErrorDomainNetDB )
 		{
 			domain = (NSString *) kCFErrorDomainCFNetwork;
-			[userInfo setObject: [NSString stringWithCString: gai_strerror(code) encoding: NSASCIIStringEncoding]
+			[userInfo setObject: [NSString stringWithCString: gai_strerror((int)code) encoding: NSASCIIStringEncoding]
 						 forKey: NSLocalizedDescriptionKey];
-			[userInfo setObject: [NSNumber numberWithInt: code]
+			[userInfo setObject: [NSNumber numberWithInt: (int)code]
 						 forKey: (NSString *)kCFGetAddrInfoFailureKey];
 		}
 		else if ( streamError.domain == kCFStreamErrorDomainNetServices )

--- a/HTTPMessage/HTTPAuthentication.h
+++ b/HTTPMessage/HTTPAuthentication.h
@@ -48,7 +48,7 @@
 
 @interface HTTPAuthentication : NSObject
 {
-	CFHTTPAuthenticationRef __strong	_internal;
+	CFHTTPAuthenticationRef	_internal;
 }
 
 + (HTTPAuthentication *) authenticationFromResponse: (HTTPMessage *) responseMessage;

--- a/HTTPMessage/HTTPAuthentication.h
+++ b/HTTPMessage/HTTPAuthentication.h
@@ -38,11 +38,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IPHONE
 #import <CFNetwork/CFHTTPAuthentication.h>
-#else
-#import <CoreServices/../Frameworks/CFNetwork.framework/Headers/CFHTTPAuthentication.h>
-#endif
 
 @class HTTPMessage;
 

--- a/HTTPMessage/HTTPMessage+GTMOAuth.h
+++ b/HTTPMessage/HTTPMessage+GTMOAuth.h
@@ -1,0 +1,17 @@
+//
+//  HTTPMessage+GTMOAuth.h
+//  My Xero Status
+//
+//  Created by Mark Aufflick on 2/08/12.
+//  Copyright (c) 2012 Pumptheory. All rights reserved.
+//
+
+#import "HTTPMessage.h"
+
+#import "GTMOAuthAuthentication.h"
+
+@interface HTTPMessage (GTMOAuth)
+
+- (void)authorizeWithGTMOAuth:(GTMOAuthAuthentication *)oauth;
+
+@end

--- a/HTTPMessage/HTTPMessage+GTMOAuth.m
+++ b/HTTPMessage/HTTPMessage+GTMOAuth.m
@@ -1,0 +1,23 @@
+//
+//  HTTPMessage+GTMOAuth.m
+//  My Xero Status
+//
+//  Created by Mark Aufflick on 2/08/12.
+//  Copyright (c) 2012 Pumptheory. All rights reserved.
+//
+
+#import "HTTPMessage+GTMOAuth.h"
+
+@implementation HTTPMessage (GTMOAuth)
+
+- (void)authorizeWithGTMOAuth:(GTMOAuthAuthentication *)oauth
+{
+    NSMutableURLRequest * requestCopy = [[self urlRequestRepresentation] mutableCopy];
+    [oauth authorizeRequest:requestCopy];
+    
+    NSDictionary * headers = requestCopy.allHTTPHeaderFields;
+    for (NSString * key in [headers allKeys])
+        [self setValue:headers[key] forHeaderField:key];
+}
+
+@end

--- a/HTTPMessage/HTTPMessage.h
+++ b/HTTPMessage/HTTPMessage.h
@@ -110,6 +110,8 @@
 // if the input stream isn't required, just discard it immediately.
 - (NSInputStream *) inputStreamUsingStreamedBodyData: (NSInputStream *) bodyStream;
 
+- (NSURLRequest *)urlRequestRepresentation;
+
 @end
 
 // HTTP version string constants

--- a/HTTPMessage/HTTPMessage.h
+++ b/HTTPMessage/HTTPMessage.h
@@ -50,7 +50,7 @@
 
 @interface HTTPMessage : NSObject <NSCopying, NSMutableCopying>
 {
-	CFHTTPMessageRef __strong	_internal;
+	CFHTTPMessageRef _internal;
 }
 
 + (HTTPMessage *) requestMessageWithMethod: (NSString *) method

--- a/HTTPMessage/HTTPMessage.h
+++ b/HTTPMessage/HTTPMessage.h
@@ -38,13 +38,8 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IPHONE
 #import <CFNetwork/CFHTTPMessage.h>
 #import <CFNetwork/CFHTTPStream.h>
-#else
-#import <CoreServices/../Frameworks/CFNetwork.framework/Headers/CFHTTPMessage.h>
-#import <CoreServices/../Frameworks/CFNetwork.framework/Headers/CFHTTPStream.h>
-#endif
 
 #import "HTTPAuthentication.h"
 

--- a/HTTPMessage/HTTPMessage.m
+++ b/HTTPMessage/HTTPMessage.m
@@ -296,4 +296,23 @@
 	return ( [result autorelease] );
 }
 
+// snarfed from AFNetworking
+NSURLRequest * AQHTTPURLRequestForHTTPMessage(CFHTTPMessageRef message);
+NSURLRequest * AQHTTPURLRequestForHTTPMessage(CFHTTPMessageRef message)
+{
+    NSURL *messageURL = [NSMakeCollectable(CFHTTPMessageCopyRequestURL(message)) autorelease];
+    
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:messageURL];
+    [request setHTTPMethod:[NSMakeCollectable(CFHTTPMessageCopyRequestMethod(message)) autorelease]];
+    [request setAllHTTPHeaderFields:[NSMakeCollectable(CFHTTPMessageCopyAllHeaderFields(message)) autorelease]];
+    [request setHTTPBody:[NSMakeCollectable(CFHTTPMessageCopyBody(message)) autorelease]];
+    
+    return request;
+}
+
+- (NSURLRequest *)urlRequestRepresentation
+{
+    return AQHTTPURLRequestForHTTPMessage(self.internalRef);
+}
+
 @end

--- a/HTTPMessage/HTTPMessage.m
+++ b/HTTPMessage/HTTPMessage.m
@@ -200,11 +200,11 @@
 }
 
 - (void) setUseGzipEncoding: (BOOL) useGzip
-{/*
+{
     if ( useGzip )
         [self setValue: @"gzip" forHeaderField: @"Accept-Encoding"];
     else
-        [self setValue: nil forHeaderField: @"Accept-Encoding"];*/
+        [self setValue: nil forHeaderField: @"Accept-Encoding"];
 }
 
 - (NSData *) serializedMessage

--- a/HTTPMessage/HTTPMessageInternalAccess.h
+++ b/HTTPMessage/HTTPMessageInternalAccess.h
@@ -40,9 +40,9 @@
 #import "HTTPAuthentication.h"
 
 @interface HTTPMessage (InternalAccess)
-@property (nonatomic, readonly, assign) CFHTTPMessageRef __strong internalRef;
+@property (nonatomic, readonly, assign) CFHTTPMessageRef internalRef;
 @end
 
 @interface HTTPAuthentication (InternalAccess)
-@property (nonatomic, readonly, assign) CFHTTPAuthenticationRef __strong internalRef;
+@property (nonatomic, readonly, assign) CFHTTPAuthenticationRef internalRef;
 @end

--- a/StreamingXMLParser/AQXMLParser.h
+++ b/StreamingXMLParser/AQXMLParser.h
@@ -61,8 +61,8 @@ extern NSString * const AQXMLParserParsingRunLoopMode;
 
 - (id) initWithData: (NSData *) data;   // creates a stream from the data
 
-@property (NS_NONATOMIC_IPHONEONLY assign) id<AQXMLParserDelegate> __weak delegate;
-@property (NS_NONATOMIC_IPHONEONLY assign) id<AQXMLParserProgressDelegate> __weak progressDelegate;
+@property (NS_NONATOMIC_IPHONEONLY assign) id<AQXMLParserDelegate>  delegate;
+@property (NS_NONATOMIC_IPHONEONLY assign) id<AQXMLParserProgressDelegate>  progressDelegate;
 
 @property (NS_NONATOMIC_IPHONEONLY assign) BOOL shouldProcessNamespaces;
 @property (NS_NONATOMIC_IPHONEONLY assign) BOOL shouldReportNamespacePrefixes;

--- a/StreamingXMLParser/AQXMLParser.m
+++ b/StreamingXMLParser/AQXMLParser.m
@@ -472,7 +472,7 @@ static xmlEntityPtr __getEntity( void * ctx, const xmlChar * name )
 	entity = xmlSAX2GetEntity( p, name );
 	if ( entity != NULL )
 	{
-		if ( p->instate & XML_PARSER_MISC|XML_PARSER_PI|XML_PARSER_DTD )
+		if ( (p->instate & XML_PARSER_MISC)|XML_PARSER_PI|XML_PARSER_DTD )
 			p->_private = (void *) 1;
 		return ( entity );
 	}

--- a/StreamingXMLParser/AQXMLParser.m
+++ b/StreamingXMLParser/AQXMLParser.m
@@ -51,11 +51,7 @@
 #import <libxml/encoding.h>
 #import <libxml/entities.h>
 
-#if TARGET_OS_IPHONE
 # import <CFNetwork/CFNetwork.h>
-#else
-# import <CoreServices/../Frameworks/CFNetwork.framework/Headers/CFNetwork.h>
-#endif
 
 #define AUTO_DEBUG_LOG_INPUT 0
 

--- a/Test/ParserComparison/ParserComparison.m
+++ b/Test/ParserComparison/ParserComparison.m
@@ -386,9 +386,9 @@ int main (int argc, char * const argv[])
         [str release];
     }
     
-    if ( ([url isFileURL] == NO) &&
-         (([[url scheme] isEqualToString: @"http"] == NO) ||
-          ([[url scheme] isEqualToString: @"https"] == NO)) )
+    if ( [url isFileURL] == NO &&
+        [[url scheme] isEqualToString: @"http"] == NO &&
+        [[url scheme] isEqualToString: @"https"] == NO )
     {
         [pool drain];
         usage();        // dead call, terminates program

--- a/Test/ParserComparison/ParserComparison.m
+++ b/Test/ParserComparison/ParserComparison.m
@@ -48,15 +48,17 @@
 #import "AQXMLParser.h"
 #import "MemoryUsageLogger.h"
 #import "AQXMLParserDelegate.h"
+#import "AFNetworking/AFHTTPRequestOperation.h"
 
 static void usage( void ) __dead2;
 static const char * MemorySizeString( mach_vm_size_t size );
 
-static const char *     _shortCommandLineArgs = "f:u:ndmah";
+static const char *     _shortCommandLineArgs = "f:u:nsdmah";
 static struct option    _longCommandLineArgs[] = {
     { "file", required_argument, NULL, 'f'},
     { "url", required_argument, NULL, 'u' },
     { "nsxmlparser", no_argument, NULL, 'n' },
+    { "streamingnsxmlparser", no_argument, NULL, 's' },
     { "nsxmldocument", no_argument, NULL, 'd' },
     { "mapped-nsxmlparser", no_argument, NULL, 'm' },
     { "aqxmlparser", no_argument, NULL, 'a' },
@@ -67,6 +69,7 @@ static struct option    _longCommandLineArgs[] = {
 enum
 {
     Test_NSXMLParserWithURL,
+    Test_StreamingNSXMLParserWithURL,
     Test_NSXMLParserWithMappedData,
     Test_NSXMLDocument,
     Test_AQXMLParser
@@ -91,6 +94,7 @@ static void usage( void )
     fprintf( stderr, "    [-u|--url]=URL             URL for an XML file to load. Must not require\n"
                      "                               authentication to access.\n" );
     fprintf( stderr, "    [-n|--nsxmlparser          Run NSXMLParser test direct from URL.\n" );
+    fprintf( stderr, "    [-s|--streamingnsxmlparser Run NSXMLParser test direct from URL using an NSInputStream.\n" );
     fprintf( stderr, "    [-m|--mapped-nsxmlparser]  Run NSXMLParser test using mapped data\n" );
     fprintf( stderr, "    [-d|--nsxmldocument]       Run NSXMLDocument test direct from URL.\n" );
     fprintf( stderr, "    [-a|--aqxmlparser]         Run AQXMLParser test (default).\n" );
@@ -248,6 +252,29 @@ static void RunNSParserTest( NSURL * url )
     [parser release];
 }
 
+static NSInputStream * StreamFromURL( NSURL * url );
+
+static void RunStreamingNSParserTest( NSURL * url )
+{
+    NSXMLParser * parser = [[NSXMLParser alloc] initWithStream:StreamFromURL(url)];
+    NumberParser * delegate = [[NumberParser alloc] init];
+    [parser setDelegate: delegate];
+    
+    fprintf( stdout, "Testing NSXMLParser from URL using AFNetworking+NSOutputStream+NSInputStream...\n" );
+    
+    CFAbsoluteTime time = CFAbsoluteTimeGetCurrent();
+    delegate.startVMSize = GetProcessMemoryUsage();
+    
+    (void) [parser parse];
+    
+    time = CFAbsoluteTimeGetCurrent() - time;
+    fprintf( stdout, "  Parsed %lu numbers\n", (unsigned long)[delegate.set count] );
+    fprintf( stdout, "  %.02f seconds, peak VM usage: %s\n", time, MemorySizeString(delegate.maxVMSize) );
+    
+    [delegate release];
+    [parser release];
+}
+
 static NSData * MappedDataFromURL( NSURL * url )
 {
     if ( [url isFileURL] )
@@ -351,6 +378,10 @@ int main (int argc, char * const argv[])
                 test = Test_NSXMLParserWithURL;
                 break;
                 
+            case 's':
+                test = Test_StreamingNSXMLParserWithURL;
+                break;
+                
             case 'm':
                 test = Test_NSXMLParserWithMappedData;
                 break;
@@ -402,6 +433,10 @@ int main (int argc, char * const argv[])
             
         case Test_NSXMLParserWithURL:
             RunNSParserTest( url );
+            break;
+            
+        case Test_StreamingNSXMLParserWithURL:
+            RunStreamingNSParserTest( url );
             break;
             
         case Test_NSXMLParserWithMappedData:

--- a/Test/ParserComparison/ParserComparison.xcodeproj/project.pbxproj
+++ b/Test/ParserComparison/ParserComparison.xcodeproj/project.pbxproj
@@ -12,6 +12,16 @@
 		388BDF1B0F8AC591004A22FD /* AQXMLParserDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 388BDF1A0F8AC591004A22FD /* AQXMLParserDelegate.m */; };
 		388BDFA90F8ACD09004A22FD /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 388BDFA80F8ACD09004A22FD /* libxml2.dylib */; };
 		388BDFBD0F8ACDF8004A22FD /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 388BDFBC0F8ACDF8004A22FD /* CoreServices.framework */; };
+		64E1075015D34C0800DEB47F /* HTTPAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1074A15D34C0800DEB47F /* HTTPAuthentication.m */; };
+		64E1075115D34C0800DEB47F /* HTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1074C15D34C0800DEB47F /* HTTPMessage.m */; };
+		64E1075215D34C0800DEB47F /* NSStream+HTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1074F15D34C0800DEB47F /* NSStream+HTTPMessage.m */; };
+		64E1075D15D34C1B00DEB47F /* b64.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1075415D34C1B00DEB47F /* b64.m */; };
+		64E1075E15D34C1B00DEB47F /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1075615D34C1B00DEB47F /* NSData+Base64.m */; };
+		64E1075F15D34C1B00DEB47F /* NSError+CFStreamError.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1075815D34C1B00DEB47F /* NSError+CFStreamError.m */; };
+		64E1076015D34C1B00DEB47F /* NSObject+Properties.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1075A15D34C1B00DEB47F /* NSObject+Properties.m */; };
+		64E1076115D34C1B00DEB47F /* NSString+PropertyKVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1075C15D34C1B00DEB47F /* NSString+PropertyKVC.m */; };
+		64E1076615D34C2C00DEB47F /* AQXMLParserInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1076315D34C2C00DEB47F /* AQXMLParserInternal.m */; };
+		64E1076715D34C2C00DEB47F /* AQXMLParserWithTimeout.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E1076515D34C2C00DEB47F /* AQXMLParserWithTimeout.m */; };
 		8DD76F9A0486AA7600D96B5E /* ParserComparison.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* ParserComparison.m */; settings = {ATTRIBUTES = (); }; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
 		8DD76F9F0486AA7600D96B5E /* ParserComparison.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = C6859EA3029092ED04C91782 /* ParserComparison.1 */; };
@@ -43,6 +53,27 @@
 		388BDF1A0F8AC591004A22FD /* AQXMLParserDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AQXMLParserDelegate.m; sourceTree = "<group>"; };
 		388BDFA80F8ACD09004A22FD /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		388BDFBC0F8ACDF8004A22FD /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
+		64E1074915D34C0800DEB47F /* HTTPAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HTTPAuthentication.h; path = ../../HTTPMessage/HTTPAuthentication.h; sourceTree = "<group>"; };
+		64E1074A15D34C0800DEB47F /* HTTPAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HTTPAuthentication.m; path = ../../HTTPMessage/HTTPAuthentication.m; sourceTree = "<group>"; };
+		64E1074B15D34C0800DEB47F /* HTTPMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HTTPMessage.h; path = ../../HTTPMessage/HTTPMessage.h; sourceTree = "<group>"; };
+		64E1074C15D34C0800DEB47F /* HTTPMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HTTPMessage.m; path = ../../HTTPMessage/HTTPMessage.m; sourceTree = "<group>"; };
+		64E1074D15D34C0800DEB47F /* HTTPMessageInternalAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HTTPMessageInternalAccess.h; path = ../../HTTPMessage/HTTPMessageInternalAccess.h; sourceTree = "<group>"; };
+		64E1074E15D34C0800DEB47F /* NSStream+HTTPMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSStream+HTTPMessage.h"; path = "../../HTTPMessage/NSStream+HTTPMessage.h"; sourceTree = "<group>"; };
+		64E1074F15D34C0800DEB47F /* NSStream+HTTPMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSStream+HTTPMessage.m"; path = "../../HTTPMessage/NSStream+HTTPMessage.m"; sourceTree = "<group>"; };
+		64E1075315D34C1B00DEB47F /* b64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = b64.h; path = ../../Extensions/b64.h; sourceTree = "<group>"; };
+		64E1075415D34C1B00DEB47F /* b64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = b64.m; path = ../../Extensions/b64.m; sourceTree = "<group>"; };
+		64E1075515D34C1B00DEB47F /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+Base64.h"; path = "../../Extensions/NSData+Base64.h"; sourceTree = "<group>"; };
+		64E1075615D34C1B00DEB47F /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Base64.m"; path = "../../Extensions/NSData+Base64.m"; sourceTree = "<group>"; };
+		64E1075715D34C1B00DEB47F /* NSError+CFStreamError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+CFStreamError.h"; path = "../../Extensions/NSError+CFStreamError.h"; sourceTree = "<group>"; };
+		64E1075815D34C1B00DEB47F /* NSError+CFStreamError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+CFStreamError.m"; path = "../../Extensions/NSError+CFStreamError.m"; sourceTree = "<group>"; };
+		64E1075915D34C1B00DEB47F /* NSObject+Properties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+Properties.h"; path = "../../Extensions/NSObject+Properties.h"; sourceTree = "<group>"; };
+		64E1075A15D34C1B00DEB47F /* NSObject+Properties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+Properties.m"; path = "../../Extensions/NSObject+Properties.m"; sourceTree = "<group>"; };
+		64E1075B15D34C1B00DEB47F /* NSString+PropertyKVC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+PropertyKVC.h"; path = "../../Extensions/NSString+PropertyKVC.h"; sourceTree = "<group>"; };
+		64E1075C15D34C1B00DEB47F /* NSString+PropertyKVC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+PropertyKVC.m"; path = "../../Extensions/NSString+PropertyKVC.m"; sourceTree = "<group>"; };
+		64E1076215D34C2C00DEB47F /* AQXMLParserInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AQXMLParserInternal.h; sourceTree = "<group>"; };
+		64E1076315D34C2C00DEB47F /* AQXMLParserInternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AQXMLParserInternal.m; sourceTree = "<group>"; };
+		64E1076415D34C2C00DEB47F /* AQXMLParserWithTimeout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AQXMLParserWithTimeout.h; sourceTree = "<group>"; };
+		64E1076515D34C2C00DEB47F /* AQXMLParserWithTimeout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AQXMLParserWithTimeout.m; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* ParserComparison */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ParserComparison; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6859EA3029092ED04C91782 /* ParserComparison.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = ParserComparison.1; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -75,6 +106,23 @@
 		08FB7795FE84155DC02AAC07 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				64E1075315D34C1B00DEB47F /* b64.h */,
+				64E1075415D34C1B00DEB47F /* b64.m */,
+				64E1075515D34C1B00DEB47F /* NSData+Base64.h */,
+				64E1075615D34C1B00DEB47F /* NSData+Base64.m */,
+				64E1075715D34C1B00DEB47F /* NSError+CFStreamError.h */,
+				64E1075815D34C1B00DEB47F /* NSError+CFStreamError.m */,
+				64E1075915D34C1B00DEB47F /* NSObject+Properties.h */,
+				64E1075A15D34C1B00DEB47F /* NSObject+Properties.m */,
+				64E1075B15D34C1B00DEB47F /* NSString+PropertyKVC.h */,
+				64E1075C15D34C1B00DEB47F /* NSString+PropertyKVC.m */,
+				64E1074915D34C0800DEB47F /* HTTPAuthentication.h */,
+				64E1074A15D34C0800DEB47F /* HTTPAuthentication.m */,
+				64E1074B15D34C0800DEB47F /* HTTPMessage.h */,
+				64E1074C15D34C0800DEB47F /* HTTPMessage.m */,
+				64E1074D15D34C0800DEB47F /* HTTPMessageInternalAccess.h */,
+				64E1074E15D34C0800DEB47F /* NSStream+HTTPMessage.h */,
+				64E1074F15D34C0800DEB47F /* NSStream+HTTPMessage.m */,
 				3824D5860FBF3A5F00F8E12D /* iPhoneNonatomic.h */,
 				388BDEFB0F8AAD12004A22FD /* StreamingXMLParser */,
 				32A70AAB03705E1F00C91783 /* ParserComparison_Prefix.pch */,
@@ -106,6 +154,10 @@
 		388BDEFB0F8AAD12004A22FD /* StreamingXMLParser */ = {
 			isa = PBXGroup;
 			children = (
+				64E1076215D34C2C00DEB47F /* AQXMLParserInternal.h */,
+				64E1076315D34C2C00DEB47F /* AQXMLParserInternal.m */,
+				64E1076415D34C2C00DEB47F /* AQXMLParserWithTimeout.h */,
+				64E1076515D34C2C00DEB47F /* AQXMLParserWithTimeout.m */,
 				388BDEFC0F8AAD12004A22FD /* AQXMLParser.h */,
 				388BDEFD0F8AAD12004A22FD /* AQXMLParser.m */,
 				388BDF190F8AC591004A22FD /* AQXMLParserDelegate.h */,
@@ -151,7 +203,11 @@
 			isa = PBXProject;
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "ParserComparison" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* ParserComparison */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -170,6 +226,16 @@
 				388BDEFE0F8AAD12004A22FD /* AQXMLParser.m in Sources */,
 				388BDF010F8AAD5F004A22FD /* MemoryUsageLogger.m in Sources */,
 				388BDF1B0F8AC591004A22FD /* AQXMLParserDelegate.m in Sources */,
+				64E1075015D34C0800DEB47F /* HTTPAuthentication.m in Sources */,
+				64E1075115D34C0800DEB47F /* HTTPMessage.m in Sources */,
+				64E1075215D34C0800DEB47F /* NSStream+HTTPMessage.m in Sources */,
+				64E1075D15D34C1B00DEB47F /* b64.m in Sources */,
+				64E1075E15D34C1B00DEB47F /* NSData+Base64.m in Sources */,
+				64E1075F15D34C1B00DEB47F /* NSError+CFStreamError.m in Sources */,
+				64E1076015D34C1B00DEB47F /* NSObject+Properties.m in Sources */,
+				64E1076115D34C1B00DEB47F /* NSString+PropertyKVC.m in Sources */,
+				64E1076615D34C2C00DEB47F /* AQXMLParserInternal.m in Sources */,
+				64E1076715D34C2C00DEB47F /* AQXMLParserWithTimeout.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -180,6 +246,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
@@ -196,6 +263,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -217,7 +285,7 @@
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -231,7 +299,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Brought in Gzip header changes from ParserExample and reduced complier warnings & depreacated GC related errors. Still get odd warnings about the weak CFNetwork symbols not being declared - perhaps because they are #defines?
