### PR TITLE
encryption key length fixed

### DIFF
--- a/CommonCrypto/NSData+CommonCrypto.m
+++ b/CommonCrypto/NSData+CommonCrypto.m
@@ -280,11 +280,11 @@ static void FixKeyLengths( CCAlgorithm algorithm, NSMutableData * keyData, NSMut
 	{
 		case kCCAlgorithmAES128:
 		{
-			if ( keyLength < 16 )
+			if ( keyLength <= 16 )
 			{
 				[keyData setLength: 16];
 			}
-			else if ( keyLength < 24 )
+			else if ( keyLength <= 24 )
 			{
 				[keyData setLength: 24];
 			}
@@ -310,7 +310,7 @@ static void FixKeyLengths( CCAlgorithm algorithm, NSMutableData * keyData, NSMut
 			
 		case kCCAlgorithmCAST:
 		{
-			if ( keyLength < 5 )
+			if ( keyLength <= 5 )
 			{
 				[keyData setLength: 5];
 			}


### PR DESCRIPTION
In you original code if the length of the key was16 or 24 it would be increased to then next acceptable length.
